### PR TITLE
feat: Configure the label of Jenkins slave

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,13 +116,14 @@ class JenkinsExecutor extends Executor {
      * Jenkins job config xml
      * @method _loadJobXml
      * @param  {Object}   config        A configuration object psssed to _start
+     * @param  {Object}   annotations   Annotaions psssed to _start
      * @return {String}
      * @private
      */
     _loadJobXml(config, annotations) {
         const { buildScript, cleanupScript } = this._taskScript(config);
         const nodeLabel = annotations[ANNOTATE_BUILD_NODE_LABEL]
-            ? this.nodeLabel.concat(`-${annotations[ANNOTATE_BUILD_NODE_LABEL]}`) : this.nodeLabel;
+            ? `${this.nodeLabel}-${annotations[ANNOTATE_BUILD_NODE_LABEL]}` : this.nodeLabel;
 
         const variables = {
             nodeLabel: xmlescape(nodeLabel),

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const password = Symbol('password');
 const baseUrl = Symbol('baseUrl');
 
 const ANNOTATE_BUILD_TIMEOUT = 'timeout';
+const ANNOTATE_BUILD_NODE_LABEL = 'nodeLabel';
 
 class JenkinsExecutor extends Executor {
     /**
@@ -118,11 +119,13 @@ class JenkinsExecutor extends Executor {
      * @return {String}
      * @private
      */
-    _loadJobXml(config) {
+    _loadJobXml(config, annotations) {
         const { buildScript, cleanupScript } = this._taskScript(config);
+        const nodeLabel = annotations[ANNOTATE_BUILD_NODE_LABEL]
+            ? this.nodeLabel.concat(`-${annotations[ANNOTATE_BUILD_NODE_LABEL]}`) : this.nodeLabel;
 
         const variables = {
-            nodeLabel: xmlescape(this.nodeLabel),
+            nodeLabel: xmlescape(nodeLabel),
             buildScript: xmlescape(buildScript),
             cleanupScript: xmlescape(cleanupScript)
         };
@@ -272,11 +275,11 @@ class JenkinsExecutor extends Executor {
      */
     async _start(config) {
         const jobName = this._jobName(config.buildId);
-        const xml = this._loadJobXml(config);
         const annotations = this.parseAnnotations(
             hoek.reach(config, 'annotations', { default: {} })
         );
 
+        const xml = this._loadJobXml(config, annotations);
         const buildTimeout = annotations[ANNOTATE_BUILD_TIMEOUT]
             ? Math.min(annotations[ANNOTATE_BUILD_TIMEOUT], this.maxBuildTimeout)
             : this.buildTimeout;

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ class JenkinsExecutor extends Executor {
      * Jenkins job config xml
      * @method _loadJobXml
      * @param  {Object}   config        A configuration object psssed to _start
-     * @param  {Object}   annotations   Annotaions psssed to _start
+     * @param  {Object}   annotations   Annotations psssed to _start
      * @return {String}
      * @private
      */

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -501,6 +501,7 @@ describe('index', () => {
                 });
 
                 const parsedAnnotations = {};
+
                 assert.equal(executor._loadJobXml(config, parsedAnnotations), xml);
             });
         });
@@ -560,6 +561,7 @@ rm -f docker-compose.yml
                 });
 
                 const parsedAnnotations = {};
+
                 assert.equal(executor._loadJobXml(config, parsedAnnotations), jobXml);
             });
 
@@ -575,7 +577,7 @@ rm -f docker-compose.yml
                     jenkins: {
                         host: 'jenkins',
                         username: 'admin',
-                        password: 'fakepassword',
+                        password: 'fakepassword'
                     },
                     docker: {
                         composeCommand,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -500,7 +500,7 @@ describe('index', () => {
                     cleanupScript: xmlescape(cleanupScript)
                 });
 
-                assert.equal(executor._loadJobXml(config), xml);
+                assert.equal(executor._loadJobXml(config, config.annotations), xml);
             });
         });
 
@@ -558,10 +558,11 @@ rm -f docker-compose.yml
                     cleanupScript: xmlescape(cleanupScript)
                 });
 
-                assert.equal(executor._loadJobXml(config), jobXml);
+                assert.equal(executor._loadJobXml(config, config.annotations), jobXml);
             });
 
             it('use provided options correctly', () => {
+                const proviededNodeLabel = 'foo-label';
                 const composeCommand = 'fake-docker-compose';
                 const prefix = 'foo-prefix';
                 const launchVersion = 'foo-ver';
@@ -574,7 +575,7 @@ rm -f docker-compose.yml
                         host: 'jenkins',
                         username: 'admin',
                         password: 'fakepassword',
-                        nodeLabel
+                        nodeLabel: proviededNodeLabel
                     },
                     docker: {
                         composeCommand,
@@ -620,12 +621,14 @@ rm -f docker-compose.yml
                 });
 
                 jobXml = tinytim.render(TEST_JOB_XML, {
-                    nodeLabel,
+                    nodeLabel: proviededNodeLabel,
                     buildScript: xmlescape(buildScript),
                     cleanupScript: xmlescape(cleanupScript)
                 });
 
-                assert.equal(executor._loadJobXml(config), jobXml);
+                config.annotations = { 'beta.screwdriver.cd/nodeLabel': proviededNodeLabel };
+
+                assert.equal(executor._loadJobXml(config, config.annotations), jobXml);
             });
         });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -500,7 +500,8 @@ describe('index', () => {
                     cleanupScript: xmlescape(cleanupScript)
                 });
 
-                assert.equal(executor._loadJobXml(config, config.annotations), xml);
+                const parsedAnnotations = {};
+                assert.equal(executor._loadJobXml(config, parsedAnnotations), xml);
             });
         });
 
@@ -558,11 +559,11 @@ rm -f docker-compose.yml
                     cleanupScript: xmlescape(cleanupScript)
                 });
 
-                assert.equal(executor._loadJobXml(config, config.annotations), jobXml);
+                const parsedAnnotations = {};
+                assert.equal(executor._loadJobXml(config, parsedAnnotations), jobXml);
             });
 
             it('use provided options correctly', () => {
-                const proviededNodeLabel = 'foo-label';
                 const composeCommand = 'fake-docker-compose';
                 const prefix = 'foo-prefix';
                 const launchVersion = 'foo-ver';
@@ -575,7 +576,6 @@ rm -f docker-compose.yml
                         host: 'jenkins',
                         username: 'admin',
                         password: 'fakepassword',
-                        nodeLabel: proviededNodeLabel
                     },
                     docker: {
                         composeCommand,
@@ -620,15 +620,16 @@ rm -f docker-compose.yml
                     composeYml
                 });
 
+                const providedNodeLabel = 'foo-label';
+                const parsedAnnotations = { nodeLabel: providedNodeLabel };
+
                 jobXml = tinytim.render(TEST_JOB_XML, {
-                    nodeLabel: proviededNodeLabel,
+                    nodeLabel: `screwdriver-${providedNodeLabel}`,
                     buildScript: xmlescape(buildScript),
                     cleanupScript: xmlescape(cleanupScript)
                 });
 
-                config.annotations = { 'beta.screwdriver.cd/nodeLabel': proviededNodeLabel };
-
-                assert.equal(executor._loadJobXml(config, config.annotations), jobXml);
+                assert.equal(executor._loadJobXml(config, parsedAnnotations), jobXml);
             });
         });
     });


### PR DESCRIPTION
## Context

To select specific Jenkins node, `nodeLabel` annotation is added in this PR.
If `nodeLabel` is not configured, the job is executed in the slave as default label (screwdriver).

## Objective

To select specific slave, annotation is added in screwdriver.yaml as below.

```
annotations:
  screwdriver.cd/executor: jenkins
  screwdriver.cd/nodeLabel: foo-label
```

## References

related PR: https://github.com/att55/executor-base/pull/1